### PR TITLE
service 테스트 작성

### DIFF
--- a/src/main/java/subway/application/in/SubwaySectionAddUsecase.java
+++ b/src/main/java/subway/application/in/SubwaySectionAddUsecase.java
@@ -1,5 +1,6 @@
 package subway.application.in;
 
+import lombok.Builder;
 import subway.domain.Kilometer;
 import subway.domain.Station;
 import subway.domain.SubwayLine;
@@ -13,6 +14,7 @@ public interface SubwaySectionAddUsecase {
         private SubwayLine.Id subwayLineId;
         private SubwaySection subwaySection;
 
+        @Builder
         public Command(SubwayLine.Id subwayLineId, SubwaySection subwaySection) {
             this.subwayLineId = subwayLineId;
             this.subwaySection = subwaySection;
@@ -42,6 +44,7 @@ public interface SubwaySectionAddUsecase {
             public SubwaySection() {
             }
 
+            @Builder
             public SubwaySection(Station.Id upStationId, Station.Id downStationId, Kilometer distance) {
                 this.upStationId = upStationId;
                 this.downStationId = downStationId;

--- a/src/main/java/subway/domain/SectionAddUpdater.java
+++ b/src/main/java/subway/domain/SectionAddUpdater.java
@@ -3,7 +3,7 @@ package subway.domain;
 import org.springframework.stereotype.Component;
 
 @Component
-class SectionAddUpdater implements SectionUpdater {
+public class SectionAddUpdater implements SectionUpdater {
     @Override
     public void apply(SubwayLine subwayLine, SubwaySection subwaySection) {
         subwayLine.addSection(subwaySection);

--- a/src/test/java/subway/application/SubwaySectionAddServiceTest.java
+++ b/src/test/java/subway/application/SubwaySectionAddServiceTest.java
@@ -1,0 +1,81 @@
+package subway.application;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import subway.application.in.SubwaySectionAddUsecase;
+import subway.application.out.StationMapLoadByInPort;
+import subway.application.out.SubwayLineLoadPort;
+import subway.application.out.SubwaySectionAddPort;
+import subway.domain.*;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+
+class SubwaySectionAddServiceTest {
+
+    private final StationMapLoadByInPort stationMapLoadByInPort = Mockito.mock(StationMapLoadByInPort.class);
+    private final SubwayLineLoadPort subwayLineLoadPort = Mockito.mock(SubwayLineLoadPort.class);
+    private final SectionUpdateManager sectionUpdateManager = new SectionUpdateManager(new SectionAddUpdater());
+    private final SubwaySectionAddPort subwaySectionAddPort = Mockito.mock(SubwaySectionAddPort.class);
+    private final SubwaySectionAddService subwaySectionAddService = new SubwaySectionAddService(stationMapLoadByInPort, subwayLineLoadPort, sectionUpdateManager, subwaySectionAddPort);
+
+
+    /**
+     * @given 지하철 역이 존재하고
+     * @given 지하철 노선이 존재한다면
+     * @when 지하철 구간을 종점역에 추가할 때
+     * @then 지하철 구간이 추가된다.
+     */
+    @Test
+    @DisplayName("지하철 역과 노선이 존재하면 지하철 구간을 종점역에 추가할 때 지하철 구간이 추가된다.")
+    void addSection() {
+        //given
+        Station 강남역 = Station.of(new Station.Id(1L), "강남역");
+        Station 역삼역 = Station.of(new Station.Id(2L), "역삼역");
+        Station 선릉역 = Station.of(new Station.Id(3L), "선릉역");
+
+        given(stationMapLoadByInPort.findAllByIn(anyList()))
+                .willReturn(Map.of(
+                        역삼역.getId(), 역삼역,
+                        선릉역.getId(), 선릉역));
+        //given
+        SubwaySection firstSection = SubwaySection.of(new SubwaySection.Id(1L), SubwaySectionStation.from(강남역), SubwaySectionStation.from(역삼역), Kilometer.of(10));
+        SubwayLine 이호선 = SubwayLine.of(new SubwayLine.Id(1L), "2호선", "green", 강남역.getId(), List.of(firstSection));
+
+        given(subwayLineLoadPort.findOne(any()))
+                .willReturn(이호선);
+
+        //when
+        SubwaySectionAddUsecase.Command.SubwaySection subwaySection = SubwaySectionAddUsecase.Command.SubwaySection
+                .builder()
+                .upStationId(역삼역.getId())
+                .downStationId(선릉역.getId())
+                .distance(Kilometer.of(10))
+                .build();
+
+        SubwaySectionAddUsecase.Command command = SubwaySectionAddUsecase.Command
+                .builder()
+                .subwayLineId(이호선.getId())
+                .subwaySection(subwaySection)
+                .build();
+
+        subwaySectionAddService.addSubwaySection(command);
+
+        //then
+        assertThat(이호선.getSections())
+                .hasSize(2)
+                .extracting("upStation.id", "downStation.id")
+                .containsExactly(
+                        tuple(강남역.getId(), 역삼역.getId()),
+                        tuple(역삼역.getId(), 선릉역.getId()));
+
+    }
+}


### PR DESCRIPTION
속도를 높여보고자 persistance layer 영역을 mocking하는 방법으로 바꿔봤습니다.

제가 느끼기에 문제는 다음과 같습니다.

1. usecase가 제대로 동작하는지 테스트하기가 어려움
    - 외부 영역의 변화를 테스트하다 외부 영역을 mocking해버리니 테스트를 해볼 것이 없어짐
2. port의 모든 동작을 mocking하다보니 port들에게 변경사항이 발생했을 때 수정이 필요해보임